### PR TITLE
Fixed to return None as default of ValueDripper

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+1.1
+---
+
+- ``None`` is default value of ``ValueDripper``
+
+  - Before this change ``ValueDripper`` without ``default`` keyword argument
+    will raise ``DrippingError``
+  - In order to this behavior ``DictDripper`` will return empty dict
+    when inner value dripper could not dig out values
+
 1.0
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,8 @@ Technically, each ends (list) will be replaced by instance of ``dripper.ValueDri
 default value
 -------------
 
-Use ``dripper.ValueDripper`` to pass converter function.
+Specify ``default`` keyword argument to change default value.
+``None`` will be applied as default.
 
 .. code-block:: python
 

--- a/dripper/drippers.py
+++ b/dripper/drippers.py
@@ -29,10 +29,7 @@ class ValueDripper(object):
         try:
             dug_in = dig_in(converting, self.source_root)
         except DrippingError:
-            if self.default is not None:
-                return self.default
-            else:
-                raise
+            return self.default
         if self.converter:
             return self.converter(dug_in)
         return dug_in

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
 
 setup(
     name='dripper',
-    version='1.0',
+    version='1.1',
     license='MIT',
     packages=['dripper'],
     install_requires=[],

--- a/tests/test_drippers.py
+++ b/tests/test_drippers.py
@@ -68,10 +68,9 @@ class TestValueDripper(TestCase):
         self.assertEqual(actual, 'default')
 
     def test__error(self):
-        from dripper.drippers import DrippingError
         target = self._makeOne(['kadoom'])
-        with self.assertRaises(DrippingError):
-            target({})
+        actual = target({})
+        self.assertIsNone(actual)
 
     def test__add(self):
         from dripper.drippers import MixDripper


### PR DESCRIPTION
- Before this change ValueDripper without default keyword argument will raise DrippingError
- In order to this behavior DictDripper will return empty dict when inner value dripper could not dig out values
