### PR TITLE
Avoid deepcopy

### DIFF
--- a/dripper/drippers.py
+++ b/dripper/drippers.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import operator
 
 from dripper.compat import reduce
@@ -6,7 +5,7 @@ from dripper.exceptions import DrippingError
 
 
 def dig_in(source, items):
-    digging = deepcopy(source)
+    digging = source
     for item in items:
         try:
             digging = digging[item]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
 
 setup(
     name='dripper',
-    version='1.1',
+    version='1.2',
     license='MIT',
     packages=['dripper'],
     install_requires=[],


### PR DESCRIPTION
hi.
this PR improve drippers performance.  Would you merge this?

we use hirokiky/dripper heavy in our production, it's readily usefull stuff. thanks.


profile
---------------------
```
# test_drippers.py is modified script.
$ .tox/py35/bin/python3.5 -m cProfile -o profile .tox/py35/bin/py.test
$ .tox/py35/bin/python3.5 -c "import pstats;pstats.Stats('profile').strip_dirs().sort_stats('cumtime').print_stats(50)"

Thu Sep 28 11:33:54 2017    profile

         1029175 function calls (858146 primitive calls) in 0.857 seconds

   Ordered by: cumulative time
   List reduced from 153 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      6/1    0.000    0.000    0.857    0.857 {built-in method builtins.exec}
        1    0.006    0.006    0.857    0.857 test_drippers.py:1(<module>)
     1000    0.007    0.000    0.849    0.001 test_drippers.py:3(test__it)
     1000    0.012    0.000    0.842    0.001 test_drippers.py:4(_callFUT)
3000/1000    0.009    0.000    0.745    0.001 drippers.py:49(__call__)
     8000    0.027    0.000    0.708    0.000 drippers.py:8(dig_in)
131000/8000    0.344    0.000    0.680    0.000 copy.py:137(deepcopy)
39000/8000    0.128    0.000    0.638    0.000 copy.py:239(_deepcopy_dict)
3000/1000    0.013    0.000    0.599    0.001 drippers.py:52(<dictcomp>)
     1000    0.004    0.000    0.285    0.000 drippers.py:65(__call__)
15000/11000    0.034    0.000    0.258    0.000 copy.py:214(_deepcopy_list)
     4000    0.005    0.000    0.250    0.000 drippers.py:28(__call__)
     1000    0.003    0.000    0.139    0.000 drippers.py:72(<listcomp>)
    54000    0.067    0.000    0.085    0.000 copy.py:253(_keep_alive)
8000/1000    0.030    0.000    0.075    0.000 drippers.py:84(dripper_factory)
3000/1000    0.008    0.000    0.057    0.000 drippers.py:94(<dictcomp>)
   268000    0.044    0.000    0.044    0.000 {method 'get' of 'dict' objects}
   247001    0.029    0.000    0.029    0.000 {built-in method builtins.id}
     3000    0.012    0.000    0.018    0.000 drippers.py:92(<dictcomp>)
    77000    0.015    0.000    0.015    0.000 copy.py:192(_deepcopy_atomic)
    61000    0.015    0.000    0.015    0.000 {method 'append' of 'list' objects}
     4000    0.007    0.000    0.008    0.000 drippers.py:19(__init__)
    48000    0.007    0.000    0.007    0.000 {method 'items' of 'dict' objects}
    19015    0.006    0.000    0.006    0.000 {built-in method builtins.isinstance}
     3000    0.005    0.000    0.006    0.000 drippers.py:42(__init__)
     ....
```

effect of PR
---------------------------

```
$ git co master
$ python3.5 drippers_speed.py
5.304681594992871

$ git co avoid-deepcopy
$ python3.5 drippers_speed.py
0.8106915480020689

$cat drippers_speed.py
def test__it():
    def _callFUT(decralation, source):
        from dripper.drippers import dripper_factory
        return dripper_factory(decralation)(source)
    source = {
        "body": {
            "articles": [
                {"title": "Title",
                 "published": {"date": ["2014-11-05"]}},
            ],
        },
        "meta": {
            "meta1": {
                "meta3": [{"author": "Author name"}]
            },
            "meta4": {"assetType": 1}
        }
    }
    declaration = {
        "articles": {
            "__type__": "list",
            "__source_root__": ['body', 'articles'],

            "title": "title",
            "title_lower": lambda d: d['title'].lower(),
            "published": ["published", "date", 0],
        },
        "meta": {
            "__source_root__": ["meta", "meta1", "meta3", 0],
            "author": "author",
        },
        "asset_type": ["meta", "meta4", "assetType"],
    }
    actual = _callFUT(declaration, source)
    return actual

if 1:
    for x in range(1000):
        test__it()
if 0:
    from timeit import Timer
    t1 = Timer("test__it()", "from __main__ import test__it")
    print(t1.timeit(10000))
```
